### PR TITLE
Fix URL-encoded filenames in download_file

### DIFF
--- a/server.py
+++ b/server.py
@@ -24,6 +24,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any
+from urllib.parse import unquote
 
 from mcp.server.fastmcp import FastMCP
 from pyrus import client
@@ -1126,7 +1127,9 @@ def download_file(
     # Sanitize filename to prevent path traversal attacks (e.g., "../../etc/passwd")
     # Path.name extracts only the filename component, stripping any directory parts
     if hasattr(response, "filename") and response.filename:
-        safe_filename = Path(response.filename).name
+        # Decode URL-encoded filename (non-ASCII chars from HTTP Content-Disposition)
+        decoded_filename = unquote(response.filename).replace('+', ' ')
+        safe_filename = Path(decoded_filename).name
         if not safe_filename:
             logger.warning(f"File {file_id} has invalid filename '{response.filename}', using fallback")
             safe_filename = f"file_{file_id}"


### PR DESCRIPTION
## Summary
- Decode URL-encoded filenames from Pyrus API
- Non-ASCII characters (Cyrillic, Japanese, etc.) now display correctly
- Convert `+` to spaces

## Problem
Files with non-ASCII names saved as `%d0%bc%d0%be%d0%b4%d0%b5%d0%bb%d1%8c` instead of `модель`.

## Changes
| Line | Change |
|------|--------|
| 27 | Add `from urllib.parse import unquote` |
| 1130 | Decode filename before `Path.name` sanitization |

## Security
- Decoding happens BEFORE `Path.name` sanitization
- Path traversal still blocked (`%2F` → `/` → stripped by `Path.name`)

## Test plan
- [ ] Download file with Cyrillic name → verify readable UTF-8
- [ ] Download file with `+` in name → verify converted to space
- [ ] Download file with `../` encoded → verify path traversal blocked

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)