### PR TITLE
Fix file upload: use correct files_host from pyrus-api

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,22 +23,35 @@ pip install -r requirements.txt
 
 ## Architecture
 
-**Single-file MCP server** (`server.py`, ~900 lines):
+**Single-file MCP server** (`server.py`):
 - Uses `FastMCP` from `mcp.server.fastmcp` with stdio transport
 - Wraps `pyrus-api` library for Pyrus API calls
 - Logs to `pyrus_mcp.log` (stdout reserved for MCP protocol)
 
 **Key components:**
 - `load_accounts()` / `get_client(account)` - Multi-account management with lazy auth
+- `_upload_file_direct()` - Direct upload using pyrus-api token (workaround for pyrus-api bug)
 - `format_*()` functions - Convert Pyrus model objects to JSON-serializable dicts
-- `@mcp.tool()` decorated functions - 21 MCP tools exposed to Claude
+- `@mcp.tool()` decorated functions - MCP tools exposed to Claude
 
 **Configuration:**
 - `accounts.json` - Credentials (gitignored, use `accounts.json.example` as template)
 - Each account has: `name`, `description`, `login`, `security_key`
 - `default_account` specifies which to use when not specified
 
-**Known issue:** The `pyrus-api` library has a bug parsing announcements - `get_announcements()` uses `response.original_response` as workaround.
+## Dependencies
+
+- `pyrus-api` (upstream, simplygoodsoftware) — Pyrus API client library
+
+**Known pyrus-api bugs and workarounds:**
+
+1. **Announcement parsing** — `get_announcements()` uses `response.original_response` to access raw JSON
+2. **File uploads** — `_upload_file_direct()` uses pyrus-api token but makes direct HTTP request to correct `_files_host` endpoint (pyrus-api sends uploads to wrong host)
+
+**Updating pyrus-api:**
+```bash
+pip install --upgrade pyrus-api
+```
 
 ## Adding New Tools
 

--- a/server.py
+++ b/server.py
@@ -16,7 +16,7 @@ Usage with Claude Desktop:
     }
 """
 
-VERSION = "0.0.2"
+VERSION = "0.0.3"
 
 import json
 import logging
@@ -27,6 +27,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 from urllib.parse import unquote
+
+import requests as http_requests  # for direct upload API call
 
 from mcp.server.fastmcp import FastMCP
 from pyrus import client
@@ -120,6 +122,50 @@ def get_client(account: str | None = None) -> client.PyrusAPI:
     logger.info(f"Authenticated account: {account}")
     pyrus_clients[account] = pyrus_client
     return pyrus_client
+
+
+def _upload_file_direct(content: bytes, filename: str, account: str | None = None) -> dict:
+    """
+    Upload file using direct HTTP request with pyrus-api token.
+
+    The pyrus-api library has a bug where uploads go to wrong host.
+    This function uses the token and correct files_host from pyrus-api
+    to make the upload request directly.
+
+    Args:
+        content: File content as bytes.
+        filename: Filename for the upload.
+        account: Account key (optional).
+
+    Returns:
+        Dict with guid, md5_hash, filename.
+    """
+    pyrus = get_client(account)
+
+    # Use the files host from pyrus-api (set during auth, e.g., s-files.pyrus.com)
+    files_host = pyrus._files_host
+    upload_url = f"https://{files_host}/v4/files/upload"
+
+    headers = {"Authorization": f"Bearer {pyrus.access_token}"}
+    files = {"file": (filename, content, "application/octet-stream")}
+
+    logger.info(f"Uploading to {upload_url}")
+    response = http_requests.post(upload_url, headers=headers, files=files)
+
+    if response.status_code != 200:
+        logger.error(f"Upload failed: HTTP {response.status_code} - {response.text}")
+        raise RuntimeError(f"Upload failed: HTTP {response.status_code}")
+
+    result = response.json()
+    if not result.get("guid"):
+        logger.error(f"Upload failed: no guid in response - {result}")
+        raise RuntimeError("Upload failed: no guid in response")
+
+    return {
+        "guid": result["guid"],
+        "md5_hash": result.get("md5_hash"),
+        "filename": filename,
+    }
 
 
 # =============================================================================
@@ -1172,33 +1218,6 @@ def download_file(
     return result
 
 
-def _handle_upload_response(response, file_path: str) -> dict:
-    """
-    Validate upload response and extract result.
-
-    Centralizes response handling to ensure consistent error messages
-    and validation across upload_file() and upload_file_content().
-    """
-    # Validate response exists
-    if response is None:
-        raise RuntimeError(f"Upload failed for {file_path}: API returned no response")
-
-    # Check for API-level errors
-    if hasattr(response, "error_code") and response.error_code:
-        raise RuntimeError(f"API error: {response.error_code}")
-
-    # Validate required fields exist
-    if not hasattr(response, "guid") or not response.guid:
-        raise RuntimeError(
-            f"Upload failed for {file_path}: API response missing 'guid' field"
-        )
-
-    return {
-        "guid": response.guid,
-        "md5_hash": getattr(response, "md5_hash", None),
-    }
-
-
 @mcp.tool()
 def upload_file(file_path: str, account: str | None = None) -> dict:
     """
@@ -1209,38 +1228,25 @@ def upload_file(file_path: str, account: str | None = None) -> dict:
         account: Account key (optional, uses default if not specified).
 
     Returns:
-        Upload result with guid for use in attachments.
+        Upload result with guid, md5_hash, and filename for use in attachments.
 
     Note:
-        File versioning (root_id) is not supported by pyrus-api library.
-        Each upload creates a new file. Use attachment_id in comment_task()
-        to reference existing files if needed.
+        Uses direct HTTP with pyrus-api token due to bugs in pyrus-api upload.
     """
-    from json import JSONDecodeError
-
-    pyrus = get_client(account)
-
     # Validate file exists (expanduser handles ~/path)
     file_path_obj = Path(file_path).expanduser()
     if not file_path_obj.exists():
         raise FileNotFoundError(f"File not found: {file_path}")
 
-    try:
-        response = pyrus.upload_file(str(file_path_obj))
-    except JSONDecodeError as e:
-        # pyrus-api returns empty/invalid JSON when upload fails silently
-        # (e.g., file rejected by server, endpoint issues)
-        logger.error(f"Upload failed for {file_path}: JSON decode error - {e}")
-        raise RuntimeError(
-            f"Upload failed: Pyrus returned invalid JSON response. "
-            f"This may indicate a server issue or the file was rejected. "
-            f"Error: {e}"
-        ) from e
-    except Exception as e:
-        logger.error(f"Upload failed for {file_path}: {e}")
-        raise
+    # Read file content
+    with open(file_path_obj, "rb") as f:
+        content = f.read()
 
-    return _handle_upload_response(response, file_path)
+    filename = file_path_obj.name
+    result = _upload_file_direct(content, filename, account)
+
+    logger.info(f"Uploaded file {filename}: guid={result['guid']}")
+    return result
 
 
 @mcp.tool()
@@ -1258,62 +1264,27 @@ def upload_file_content(
         account: Account key (optional, uses default if not specified).
 
     Returns:
-        Upload result with guid for use in attachments.
+        Upload result with guid, md5_hash, and filename for use in attachments.
+
+    Note:
+        Uses direct HTTP with pyrus-api token due to bugs in pyrus-api upload.
     """
     import base64
     import binascii
-    from json import JSONDecodeError
-
-    pyrus = get_client(account)
 
     # Decode base64 content
-    # Catch only binascii.Error (what base64.b64decode raises for invalid input)
-    # to avoid masking unrelated errors like MemoryError for huge payloads
     try:
         content = base64.b64decode(content_base64)
     except binascii.Error as e:
         raise ValueError(f"Invalid base64 content: {e}") from e
 
-    # Sanitize filename to prevent path traversal, preserve original name
-    # Using Path().name extracts just the filename without any directory components
+    # Sanitize filename to prevent path traversal
     safe_filename = Path(filename).name or "upload"
 
-    # Use a temp directory (not NamedTemporaryFile) so the file keeps its original name
-    # (pyrus-api uses the filename from the path when uploading to Pyrus)
-    tmp_dir = None
-    tmp_path = None
-    try:
-        tmp_dir = tempfile.mkdtemp(prefix="pyrus_upload_")
-        tmp_path = Path(tmp_dir) / safe_filename
-        tmp_path.write_bytes(content)
+    result = _upload_file_direct(content, safe_filename, account)
 
-        response = pyrus.upload_file(str(tmp_path))
-        return _handle_upload_response(response, filename)
-
-    except JSONDecodeError as e:
-        # pyrus-api returns empty/invalid JSON when upload fails silently
-        logger.error(f"Upload failed for {filename}: JSON decode error - {e}")
-        raise RuntimeError(
-            f"Upload failed: Pyrus returned invalid JSON response. "
-            f"This may indicate a server issue or the file was rejected. "
-            f"Error: {e}"
-        ) from e
-    except Exception as e:
-        logger.error(f"Upload failed for {filename}: {e}")
-        raise
-    finally:
-        # Clean up temp file and directory
-        # Cleanup errors are logged but don't fail the operation
-        if tmp_path and tmp_path.exists():
-            try:
-                tmp_path.unlink()
-            except OSError as e:
-                logger.warning(f"Failed to clean up temp file {tmp_path}: {e}")
-        if tmp_dir:
-            try:
-                os.rmdir(tmp_dir)
-            except OSError as e:
-                logger.warning(f"Failed to clean up temp dir {tmp_dir}: {e}")
+    logger.info(f"Uploaded file {safe_filename}: guid={result['guid']}")
+    return result
 
 
 @mcp.tool()


### PR DESCRIPTION
## Summary

- pyrus-api library has a bug: sends uploads to `api.pyrus.com` instead of the correct `_files_host`
- After auth, pyrus-api client receives correct files host (e.g., `s-files.pyrus.com`)
- New `_upload_file_direct()` reuses pyrus-api token but makes upload to correct host
- Simplified `upload_file()` and `upload_file_content()` — no more temp file handling

## Test plan

Tested on task #2002200740 with affix account:
- [x] `upload_file(file_path)` — returns guid ✅
- [x] `upload_file_content(base64, filename)` — returns guid ✅
- [x] `attach_file_to_task(task_id, content_base64, filename)` — attaches file ✅

## Root cause

```python
# pyrus-api client.py line 727:
url = self._create_files_url(path) if get_file else self._create_url(path)
#                                    ^^^^^^^^ only True for downloads!
```

File uploads use `get_file=False`, so they go to `_host` (api.pyrus.com) instead of `_files_host`.

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)